### PR TITLE
Making sure that vagrant_manage_hosts behaves like docker_manage_hosts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,25 @@
 ---
+- name: Import Vagrant host variables
+  include_vars:
+    file: "{{ playbook_dir }}/vagrant_hosts.yml"
+
+- name: Halt Vagrant boxes
+  include_tasks: "vagrant_halt.yml"
+  with_items: "{{ vagrant_host_list }}"
+  when: (taskname == "vagrant_up") and (taskname is defined)
+
+- name: Destroy Vagrant boxes
+  include_tasks: "vagrant_destroy.yml"
+  with_items: "{{ vagrant_host_list }}"
+  when: (taskname == "vagrant_up") and (taskname is defined)
+
 - name: Generate Vagrantfile and config.yml
   include_tasks: vagrant_generate_files.yml
-  with_items: "{{ vagrant_vm_list }}"
+  with_items: "{{ vagrant_host_list }}"
   when: (taskname == "vagrant_up") and (taskname is defined)
 
 - name: Start Vagrant boxes
   include_tasks: "vagrant_up.yml"
-  with_items: "{{ vagrant_vm_list }}"
+  with_items: "{{ vagrant_host_list }}"
   when: (taskname == "vagrant_up") and (taskname is defined)
-
-- name: Halt Vagrant boxes
-  include_tasks: "vagrant_halt.yml"
-  with_items: "{{ vagrant_vm_list }}"
-  when: (taskname == "vagrant_halt") and (taskname is defined)
-
-- name: Destroy Vagrant boxes
-  include_tasks: "vagrant_destroy.yml"
-  with_items: "{{ vagrant_vm_list }}"
-  when: (taskname == "vagrant_destroy") and (taskname is defined)
 ...

--- a/tasks/vagrant_destroy.yml
+++ b/tasks/vagrant_destroy.yml
@@ -1,7 +1,18 @@
 ---
+- name: Check if the vagrant folder exists
+  stat: path="{{ item.vagrant_folder }}"
+  register: vagrant_folder
+
 - name: Destroy Vagrant virtual machines
   command: "vagrant destroy"
   args:
     chdir: "{{ item.vagrant_folder }}"
   changed_when: false
+  when: vagrant_folder.stat.exists == True
+
+- name: Removing the vagrant folder
+  file:
+    name: "{{ item.vagrant_folder }}"
+    state: absent
+  when: vagrant_folder.stat.exists == True
 ...

--- a/tasks/vagrant_halt.yml
+++ b/tasks/vagrant_halt.yml
@@ -1,7 +1,12 @@
 ---
+- name: Check if the vagrant folder exists
+  stat: path="{{ item.vagrant_folder }}"
+  register: vagrant_folder
+
 - name: Halt Vagrant virtual machines
   command: "vagrant halt"
   args:
     chdir: "{{ item.vagrant_folder }}"
   changed_when: false
+  when: vagrant_folder.stat.exists == True
 ...


### PR DESCRIPTION
Enabling users to use vagrant_manage_hosts just like docker_manage_hosts

Similar execution like for the docker equivalent:

Create a vagrant_hosts.yml 
```
---
host_group: "managed"
vagrant_host_list:
  - {host: "localhost", vagrant_folder: "/home/user/vagrant/myvm.example.com"}
vagrant_box: "centos/7"
vagrant_vm_list:
  - {hostname: myvm.example.com, vagrant_folder: "/home/user/vagrant/myvm.example.com"}
```

Add a requirements.yml
```
- name: vagrant_manage_hosts
  src: https://github.com/prometeo-cloud/vagrant_manage_hosts
```

Modify the site.yml
```
$ cat site.yml 
---
- name: Start Managed Hosts
  hosts: localhost
  roles:
    - {role: docker_manage_hosts, taskname: "start_host", when: host_type == "docker"}
    - {role: vagrant_manage_hosts, taskname: "vagrant_up", when: host_type == "vagrant"}

- name: Testing Configuration...
  hosts: managed
  vars:
    ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
  roles:
    - mysuperduperrole
  tags: ansible

- name: Delete managed host
  hosts: localhost
  roles:
    - {role: docker_manage_hosts, taskname: "delete_host", when: host_type == "docker"}
    - {role: vagrant_manage_hosts, taskname: "delete_host", when: host_type == "vagrant"}
...
$
``` 

Execute it:
```
user@host $ ansible-galaxy install -r requirements.yml -p ./roles
user@host $ ansible-playbook -i inventory site.yml --extra-vars "host_type=vagrant"
```
